### PR TITLE
✨ Adds Lutron Certificate add-on

### DIFF
--- a/.hassio-addons.yml
+++ b/.hassio-addons.yml
@@ -61,6 +61,10 @@ addons:
     repository: hassio-addons/addon-lovelace-migration
     target: lovelace-migration
     image: hassioaddons/lovelace-migration
+  lutron-cert:
+    repository: hassio-addons/addon-lutron-cert
+    target: lutron-cert
+    image: hassioaddons/lutron-cert
   mqtt:
     repository: hassio-addons/addon-mqtt
     target: mqtt


### PR DESCRIPTION
# Proposed Changes

> This PR will add the [Lutron Certificate](https://github.com/hassio-addons/addon-lutron-cert) add-on to the edge repository.

## Related Issues

> N/A