### PR TITLE
Correct link for image in the prometheus add-on

### DIFF
--- a/prometheus/config.yaml
+++ b/prometheus/config.yaml
@@ -5,7 +5,7 @@ arch:
 description: Cloud native metrics
 hassio_api: true
 homeassistant_api: true
-image: hassioaddons/prometheus-{arch}
+image: ghcr.io/hassio-addons/prometheus/{arch}
 ingress: true
 ingress_entry: graph
 ingress_port: 9090


### PR DESCRIPTION
# Proposed Changes

The prometheus add-on still has a dockerhub link for its image but the add-on itself is now publishing its images to `ghcr.io`. This corrects the image link so people can try out this edge add-on.