### PR TITLE
✨ Add Syncthing

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -141,6 +141,10 @@ apps:
     repository: hassio-addons/app-sqlite-web
     target: sqlite-web
     image: ghcr.io/hassio-addons/sqlite-web
+  syncthing:
+    repository: hassio-addons/app-syncthing
+    target: syncthing
+    image: ghcr.io/hassio-addons/syncthing
   tailscale:
     repository: hassio-addons/app-tailscale
     target: tailscale


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the Syncthing app to the edge store.

Syncthing is a continuous file synchronization program. The app has just been modernized in [hassio-addons/app-syncthing](https://github.com/hassio-addons/app-syncthing): it now runs Syncthing v2.1.3 on `ghcr.io/hassio-addons/base` for aarch64 and amd64, uses s6-rc v3, and serves its web interface through NGINX so Ingress works.

CI on the app repository is green and the multi-arch image has been built and pushed to `ghcr.io/hassio-addons/syncthing`.

Edge only for now. The repository updater skips draft releases, and outside the edge channel it has no commit fallback, so adding this to beta or stable before an actual release is published would leave `latest_commit` unset and break the updater run for every app in that channel. Happy to open those two once a release is cut.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Syncthing app to the available app catalog.
  * Configured its repository, build target, and container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->