### PR TITLE
:sparkles: Add qBittorrent to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -109,6 +109,10 @@ apps:
     repository: hassio-addons/app-plex
     target: plex
     image: ghcr.io/hassio-addons/plex
+  qbittorrent:
+    repository: hassio-addons/app-qbittorrent
+    target: qbittorrent
+    image: ghcr.io/hassio-addons/qbittorrent
   spotify:
     repository: hassio-addons/app-spotify-connect
     target: spotify


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new qBittorrent app to the store.

qBittorrent is an open source BitTorrent client with no advertising, no bundled extras and no account. This app runs the headless build, so what you get is the web interface: a queue with limits, categories and tags that decide where files land, RSS feeds, scheduling, and a full API. Downloads land in the `media` folder, which puts them in reach of the media browser and of the Sonarr, Radarr and Lidarr apps. Home Assistant has an integration for it, so the speeds and the torrent counts can sit on a dashboard.

Behind Ingress it needs no address rewriting, which is unusual for this kind of app. qBittorrent 5's WebUI resolves every URL against `window.location`, so it finds the Ingress path on its own and needs none of the `sub_filter` work the SABnzbd and Mealie apps do to fix up paths.

It does need three one-line corrections, for a different reason. Ingress frames the panel inside Home Assistant, and `color-scheme.js`, `misc.js` and MochaUI's modal underlay all assume the window above them is qBittorrent's own. That holds for its dialogs, which really are framed by the main window, and breaks for the main window itself, where each of them threw before the interface had finished being built and left a half drawn page with an unfinished toolbar. Those scripts are Qt resources compiled into `qbittorrent-nox`, so NGINX corrects the three lines as they pass through, each by falling back to the app's own window exactly the way qBittorrent's `dynamicTable.js` already does for the same value.

NGINX earns its place three more times, and each was confirmed load-bearing by testing with and without it: the `Host` header has to name the backend or qBittorrent rejects the port mismatch, the `Origin` and `Referer` headers have to be dropped or its CSRF check refuses Home Assistant's origin, and the Supervisor has to be the only address let in. That is also what gives the login model: the panel opens without a password because NGINX proxies from loopback and qBittorrent is set to skip authentication there, while anything reaching the published port still meets qBittorrent's own login.

Checked in a headless browser inside a real iframe behind a Supervisor stand-in, with the console clean and the panel fully drawn. Also verified in a container: both login paths, the SSL option, first run seeding, and a restart leaving a changed save path alone while putting the app owned settings back.

It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-qbittorrent

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
