### PR TITLE
:sparkles: Add Jellyfin to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -65,6 +65,10 @@ apps:
     repository: hassio-addons/addon-influxdb
     target: influxdb
     image: ghcr.io/hassio-addons/influxdb/{arch}
+  jellyfin:
+    repository: hassio-addons/app-jellyfin
+    target: jellyfin
+    image: ghcr.io/hassio-addons/jellyfin
   jupyterlab:
     repository: hassio-addons/addon-jupyterlab
     target: jupyterlab


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Jellyfin app to the edge store index.

Jellyfin is a media server. It indexes the films, series and music in the
`media` and `share` folders, collects the artwork and descriptions for them,
and serves the lot to browsers and to the Jellyfin apps on phones, tablets,
TVs and games consoles. The app is built on the Debian base, opens in a
sidebar panel through Ingress, and ships the patched FFmpeg the Jellyfin
project builds, so transcoding can be handed to an Intel or AMD graphics chip.

- App repository: hassio-addons/app-jellyfin
- Image: `ghcr.io/hassio-addons/jellyfin`

Edge resolves an app from the latest commit on its default branch rather than
from a release, so this one is ready to merge as it stands.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

hassio-addons/app-jellyfin

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Jellyfin as an available app.
  * Configured the Jellyfin app with its repository, build target, and container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->