### PR TITLE
:sparkles: Add Audiobookshelf to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -17,6 +17,10 @@ apps:
     repository: hassio-addons/app-appdaemon
     target: appdaemon
     image: ghcr.io/hassio-addons/appdaemon
+  audiobookshelf:
+    repository: hassio-addons/app-audiobookshelf
+    target: audiobookshelf
+    image: ghcr.io/hassio-addons/audiobookshelf
   bazarr:
     repository: hassio-addons/addon-bazarr
     target: bazarr


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Audiobookshelf app to the store.

Audiobookshelf is a self-hosted server for audiobooks and podcasts. It reads the folders you point it at, works out what the files are, fetches covers and descriptions, and serves them to a player that keeps everybody's position in every book. Progress follows the listener rather than the device, so a book started on a phone carries on from the same second in a browser at home. Podcasts are subscribed to and downloaded by the server itself, on a schedule. Libraries live under `media` or `share` and are never moved or rewritten.

The interesting part is Ingress. Audiobookshelf's web client is a Nuxt 2 application generated ahead of time, and the base path everything is addressed from is compiled into it. Upstream hardcodes that to `/audiobookshelf` and says a configurable subdirectory is not supported, which is exactly the shape Ingress cannot satisfy, since it settles on a path per request.

It turns out to be reachable anyway, and much more cheaply than the Mealie app was. The client is built for the site root, and NGINX writes the Ingress path into the 8KB HTML document on the way past. Four values in `window.__NUXT__.config` carry it, and Nuxt only ever reads that object rather than replacing it: `_app.basePath` is preferred over the compiled value by vue-router, `_app.assetsPath` becomes `__webpack_public_path__` so every lazily loaded chunk follows, `routerBasePath` is what Audiobookshelf's own components and store build URLs from, and `axios.baseURL` is read back by `@nuxtjs/axios` in preference to what it was built with. The megabytes of JavaScript are never touched.

One thing was out of reach of that. `process.env.serverUrl` is a compile time substitution, used at 18 call sites for addresses the browser follows by itself: the download links, the OIDC callback, the chapter editor's audio element and the player's own track source. No interceptor can reach those. Rather than patch every call site, which is what Mealie needed and what rots on each upstream release, the patch repoints the substitution itself at the runtime config with a single `webpack.DefinePlugin` in `nuxt.config.js`. Every current call site is carried, and so is any added upstream later. The whole patch is one file.

The same patch turns off the PWA service worker. One registered against an Ingress path is orphaned as soon as that path changes, and Audiobookshelf already had offline support and asset caching switched off, so nothing is given up. It also stops the client fetching Workbox from a CDN at runtime.

Verified end to end against the built image with a Supervisor stand-in: every absolute URL in the served page comes back carrying the Ingress path, all four runtime values are rewritten, a `_nuxt` chunk resolves at the rewritten path with the right MIME type, and `/login` redirects to `/api/hassio_ingress/<token>/login/`. A check for anything still pointing at the site root came back empty. HLS playback needed nothing: the playlists reference their segments relatively, so they inherit the prefix on their own.

A few smaller things. ffmpeg, ffprobe and the nunicode SQLite extension are all in the image and pointed at explicitly, because Audiobookshelf otherwise downloads them from the internet on startup when it cannot find them. The nunicode extension loads, so search folds accents and unicode properly. The app runs on Alpine, which is what upstream builds and tests on, and the mobile apps, RSS feeds and share links are the reasons to publish the port, since none of them can use an Ingress address.

It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-audiobookshelf

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Audiobookshelf as an available app.
  * Configured its repository, target, and container image for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->