### PR TITLE
:fire: Remove stale VSCode Remote entry from apps config

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -205,10 +205,6 @@ apps:
     repository: hassio-addons/app-vscode
     target: vscode
     image: ghcr.io/hassio-addons/vscode
-  vscode-remote:
-    repository: hassio-addons/app-vscode-remote
-    target: vscode-remote
-    image: ghcr.io/hassio-addons/vscode-remote
   whisparr:
     repository: hassio-addons/app-whisparr
     target: whisparr


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Every `Repository Updater` run has been failing since #88 was merged. The updater loads all apps from `.apps.yml` up front and aborts on the first error, so a single bad entry blocks every update dispatch:

```
Loading app vscode-remote
...
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", ...}
```

The VSCode Remote add-on was removed from this repository in #49 (March 2023) and its source repository `hassio-addons/addon-vscode-remote` was archived at that point. Its `.apps.yml` entry was left behind, and kept working only because the archived repository still resolved. The Apps rename housekeeping in #88 blanket-renamed all `repository:` values from `addon-*` to `app-*`, which pointed this entry at `hassio-addons/app-vscode-remote`, a repository that does not exist.

This PR removes the stale `vscode-remote` entry. All other `repository:` entries in `.apps.yml` were verified to resolve. There is no `vscode-remote/` directory and no README reference, so nothing else needs to change.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

- #49
- #88

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the `vscode-remote` application entry from the available app configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->