### PR TITLE
:sparkles: Add Actual Budget to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -1,6 +1,10 @@
 ---
 channel: edge
 apps:
+  actual-budget:
+    repository: hassio-addons/app-actual-budget
+    target: actual-budget
+    image: ghcr.io/hassio-addons/actual-budget
   adguard:
     repository: hassio-addons/app-adguard-home
     target: adguard


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Actual Budget app to the store.

Opened as a draft on purpose. The stable store entry is in hassio-addons/repository#814, which has the full description.

Actual is a local-first envelope budgeting app, run here on Alpine from the published npm package with NGINX in front for Ingress. It builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-actual-budget

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

hassio-addons/repository#814

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Actual Budget app to the available applications catalog.
  - Configured its published container image and source repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->