### PR TITLE
:sparkles: Add Calibre-Web to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -37,6 +37,10 @@ apps:
     repository: hassio-addons/app-bookstack
     target: bookstack
     image: ghcr.io/hassio-addons/bookstack
+  calibre-web:
+    repository: hassio-addons/app-calibre-web
+    target: calibre-web
+    image: ghcr.io/hassio-addons/calibre-web
   chrony:
     repository: hassio-addons/app-chrony
     target: chrony


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new Calibre-Web app to the store.

Calibre-Web is a web interface for a Calibre book library: cover art, search, authors and series, shelves and reading progress per person, and a reader in the browser for EPUB, PDF, comics and audiobooks. It is not Calibre and does not try to be. Calibre stays the program a collection is managed with; Calibre-Web is how the rest of the house gets to it, from a phone, a tablet or an e-reader. It also publishes an OPDS catalogue for reading apps, mails books to a Kindle, and can stand in for the Kobo store so a Kobo syncs against your own library.

Ingress needed nothing clever this time. Calibre-Web reads `X-Script-Name` and builds every link around it, so NGINX passes Home Assistant's per-session Ingress path in that header and the app does the rest: no patches, nothing rewritten on the way past. Verified through NGINX against the built image: with the header every `href` and `src` in the page comes back carrying the Ingress path, without it they are root-relative.

Calibre-Web listens on a Unix socket rather than a port. Its listening port lives in its own settings database and is editable from its admin page, so a port would have been one saved form away from a broken panel. With `CALIBRE_UNIX_SOCKET` set, NGINX serves both Ingress and the optional published port from that socket, and the port field on the configuration page does nothing.

The larger part of the image is calibre itself, which is what makes the "Convert book" button, Send to eReader and the metadata read out of an upload actually work. Calibre is not packaged for Alpine outside edge/testing, and Debian's package pulls in the whole Qt desktop stack for 1.2 GB. Upstream's own bundle is self-contained, ships for both x86_64 and arm64, and can be pinned, so the image uses that, trimmed from 630 MB to 517 MB: the read-aloud voices and their ML runtime, calibre's own content server front end, Chromium's devtools, and every interface translation except the single English pak QtWebEngine insists on. Every conversion path was tested on the trimmed tree, including PDF output, which needed Chromium's `--no-sandbox` (it refuses to run as root otherwise) and three X libraries beyond the usual list. kepubify is in the image too, for Kobo.

First start lands in a working app rather than the setup wizard. The init creates an empty Calibre library at `/media/books` when there is none there yet (an existing one is adopted as it stands), has Calibre-Web build its own settings database with a dry run of its updater, then writes the library path in and switches uploading on. Uploading is off in a stock Calibre-Web, which on a brand new library leaves no way to put a book in it at all. Calibre-Web's self-updater is switched off through upstream's own flag, since it would write a release nobody chose over the image's files.

It runs on Debian, builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-calibre-web

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Calibre-Web app to the available app catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->