### PR TITLE
:sparkles: Add NZBGet to app store

### DIFF
--- a/.apps.yml
+++ b/.apps.yml
@@ -117,6 +117,10 @@ apps:
     repository: hassio-addons/app-nut
     target: nut
     image: ghcr.io/hassio-addons/nut
+  nzbget:
+    repository: hassio-addons/app-nzbget
+    target: nzbget
+    image: ghcr.io/hassio-addons/nzbget
   overseerr:
     repository: hassio-addons/app-seerr
     target: seerr


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Adds the new NZBGet app to the store.

NZBGet is a Usenet downloader written in C++ for hardware that had nothing to spare, which on anything larger means downloads that fill the line while the rest of the machine carries on. Handing it an nzb file is the whole job: it fetches the articles, checks them against their par2 files and repairs what arrived damaged, unpacks the archives and passes the result on to whatever should run afterwards. Categories decide where things land, RSS feeds pull new items in on their own, and there is a JSON-RPC API for the rest, which is what the Home Assistant integration talks to.

It runs on Debian and installs from the `.deb` upstream publishes for amd64 and arm64, unpacked rather than installed: the maintainer scripts add a system user and a systemd unit, and neither means anything in a container. The binary is statically linked, so nothing else is needed at runtime. Unpacking it over `/` turned out not to be the shortcut it looks like, since the package carries a `/lib` directory and that replaces the symlink Debian's merged-`/usr` layout rests on (the linker then loses `libm`). `unrar` is built from rarlab source, the way the SABnzbd and Bazarr apps already do it, pinned to 7.1.10 rather than the newer 7.2.1 because that one is a beta. 7-Zip, NGINX and Python 3 come from Debian, version-pinned for Renovate.

Ingress needed nothing clever. NZBGet's web interface addresses everything relative to the page it was served from and checks neither `Host` nor `Origin`, so NGINX is a plain `proxy_pass` with none of the patching the qBittorrent app needed. The panel opens without a login because NZBGet is told that clients on loopback need none, which is where NGINX hands the Ingress requests over from; the published port keeps NZBGet's own login. NZBGet ships with the same password for everybody, so the first start replaces it with a generated one, writes it to the log once, and it stays editable under Settings > SECURITY from then on.

Everything that has to keep matching the container is passed on the command line rather than left in the configuration file: the paths (state in the configuration folder, program files in the image), the control port, the loopback exemption, and where log messages go. Verified against the built image that these survive a "Save all changes" and reload from the settings screen, with deliberately hostile values in the file. What the user should own is seeded once on the first start and then left alone: downloads go to `/media/nzbget`, and the unpack commands stay editable because extra switches are the reason NZBGet takes commands there rather than paths. The app's `log_level` is spread over NZBGet's five per-severity log targets, with the default reproducing stock screen output.

There is no SSL option, unlike the qBittorrent app: NZBGet serves TLS on a second port rather than on the same one, and that port is not published, so the option would do nothing. The docs point at NGINX Proxy Manager instead.

Builds for aarch64 and amd64, and lives at https://github.com/hassio-addons/app-nzbget

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
